### PR TITLE
test: emit QA observer events for test coverage and flakiness

### DIFF
--- a/.jules/exchange/events/prepare_release_missing_retry_tests_qa.md
+++ b/.jules/exchange/events/prepare_release_missing_retry_tests_qa.md
@@ -1,0 +1,31 @@
+---
+label: "tests"
+created_at: "2024-03-25"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+The test suite for `prepareRelease` does not validate the bounded retry logic or conflict recovery mechanisms for `GitHubApiError` statuses.
+
+## Goal
+
+Add tests to ensure `prepareRelease` successfully retries on retryable statuses (e.g., 500), handles 409 conflicts correctly by checking for converged state, and fails accurately when retries are exhausted.
+
+## Context
+
+`prepareRelease` implements a robust retry policy for draft release creation using `releaseMutationRetryPolicy`, `isRetryableGitHubStatus`, and `isConflictStatus`. The `tests/app/prepare-release.test.ts` suite only checks the "happy path" and validation failure cases. If the retry logic or conflict recovery were broken during a refactor, no tests would fail, violating the goal of testing externally visible behavior.
+
+## Evidence
+
+- path: "tests/app/prepare-release.test.ts"
+  loc: "Entire file"
+  note: "No assertions cover `createDraftRelease` throwing `GitHubApiError` with retryable statuses."
+- path: "src/app/prepare-release.ts"
+  loc: "Lines 36-69"
+  note: "Implementation contains complex bounded retry and conflict resolution logic not covered by tests."
+
+## Change Scope
+
+- `tests/app/prepare-release.test.ts`

--- a/.jules/exchange/events/release_files_shared_mutable_state_qa.md
+++ b/.jules/exchange/events/release_files_shared_mutable_state_qa.md
@@ -1,0 +1,31 @@
+---
+label: "tests"
+created_at: "2024-03-25"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+The test suite `tests/adapters/release-files.test.ts` uses a module-level mutable array `temporaryDirectories` to track state across isolated tests, risking order-dependent flakes.
+
+## Goal
+
+Refactor the test setup to track resources using test-scoped or `beforeEach` scoped contexts instead of a global array.
+
+## Context
+
+Using a shared, mutable top-level array across an entire `describe` block means that if tests are run in parallel, or if an early failure leaves resources in an unknown state, subsequent tests might fail. It violates the "Isolation By Design" principle which mandates avoiding shared mutable state to prevent hidden ordering constraints and flakiness. The cleanup should be tied to the execution context of individual tests or localized lifecycle hooks safely.
+
+## Evidence
+
+- path: "tests/adapters/release-files.test.ts"
+  loc: "Line 8"
+  note: "`const temporaryDirectories: string[] = []` creates shared module-level mutable state."
+- path: "tests/adapters/release-files.test.ts"
+  loc: "Lines 11-19"
+  note: "An `afterEach` hook mutates the global state to attempt cleanup, which can fail if Vitest executes other hooks or tests concurrently."
+
+## Change Scope
+
+- `tests/adapters/release-files.test.ts`

--- a/.jules/exchange/events/upload_release_assets_missing_unmatched_files_test_qa.md
+++ b/.jules/exchange/events/upload_release_assets_missing_unmatched_files_test_qa.md
@@ -1,0 +1,31 @@
+---
+label: "tests"
+created_at: "2024-03-25"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+The test suite for `uploadReleaseAssets` validates the failure case when files are unmatched, but does not validate the fallback case when `failOnUnmatchedFiles` is false.
+
+## Goal
+
+Add a test case ensuring that `uploadReleaseAssets` gracefully skips upload without throwing an error and returns the unchanged release metadata when `failOnUnmatchedFiles` is false.
+
+## Context
+
+The `uploadReleaseAssets` application code explicitly implements logic to conditionally fail when no files match the input patterns, depending on the `failOnUnmatchedFiles` flag. The current test suite `tests/app/upload-release-assets.test.ts` only tests the path where `failOnUnmatchedFiles` is true. Testing the "skip" fallback path is critical for ensuring non-breaking CI pipelines when optional assets are omitted.
+
+## Evidence
+
+- path: "tests/app/upload-release-assets.test.ts"
+  loc: "Entire file"
+  note: "No assertions verify the success outcome when `failOnUnmatchedFiles` is false and files are unmatched."
+- path: "src/app/upload-release-assets.ts"
+  loc: "Lines 34-45"
+  note: "Conditional logic skipping execution and returning default metadata when `failOnUnmatchedFiles` is false is untested."
+
+## Change Scope
+
+- `tests/app/upload-release-assets.test.ts`


### PR DESCRIPTION
Added 3 QA observer events:
- Missing retry logic coverage in prepareRelease
- Missing unmatched files fallback coverage in uploadReleaseAssets
- Shared mutable state flake risk in release-files.test.ts

---
*PR created automatically by Jules for task [6078295670010662478](https://jules.google.com/task/6078295670010662478) started by @akitorahayashi*