### PR TITLE
docs: Emit taxonomy events for terminology analysis

### DIFF
--- a/.jules/exchange/events/ambiguous_release_id_naming_taxonomy.md
+++ b/.jules/exchange/events/ambiguous_release_id_naming_taxonomy.md
@@ -1,0 +1,34 @@
+---
+label: "refacts"
+created_at: "2026-03-25"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The release identifier has ambiguous and generic names in different contexts: `release_id` (action input/output), `releaseId` (action requests, action results, and adapter method signatures), and simply `id` inside `ReleaseRecord`. Additionally, `ReleaseAssetRecord` uses `id` for its own identifier.
+
+## Goal
+
+Establish consistent naming for the canonical identifier of a release to avoid ambiguity when working across domain records, adapter methods, and action payloads.
+
+## Context
+
+`ReleaseRecord` has `id: number`. `ReleaseAssetRecord` has `id: number`. However, `GitHubReleaseApi` uses `releaseId: number` as arguments, and `ActionResult` uses `releaseId: number`. A generic `id` inside a record is idiomatic in some systems, but can be confusing when passed around alongside an asset `id`. Consistent use of `releaseId` vs `id` needs taxonomy definition.
+
+## Evidence
+
+- path: "src/domain/release-record.ts"
+  loc: "10: id: number"
+  note: "Uses generic 'id' for the release identifier."
+- path: "src/action/outputs.ts"
+  loc: "5: releaseId: number"
+  note: "Uses specific 'releaseId'."
+- path: "src/adapters/github/release-api.ts"
+  loc: "updateRelease(..., releaseId: number, ...)"
+  note: "Uses specific 'releaseId' in method signature."
+
+## Change Scope
+
+- `src/domain/release-record.ts`

--- a/.jules/exchange/events/files_vs_patterns_mismatch_taxonomy.md
+++ b/.jules/exchange/events/files_vs_patterns_mismatch_taxonomy.md
@@ -1,0 +1,36 @@
+---
+label: "refacts"
+created_at: "2026-03-25"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+There is a mismatch between the external vocabulary and internal code representation for upload targets: the public CLI action input is `files`, but internally the parsed array is named `patterns` (in `UploadActionRequest` and `UploadAssetPlan`), and then the resolved files on disk are again named `files`.
+
+## Goal
+
+Align the internal code vocabulary with the external action input and the conceptual domain. If the input represents glob patterns, `patterns` or `filePatterns` may be the correct canonical term, and error messages should consistently reflect the boundary context.
+
+## Context
+
+`UploadActionRequest` has `patterns: string[]`. `parseFilePatterns` converts the `files` string input into a `string[]` of patterns. `UploadAssetPlan` has `patterns: string[]`. `uploadReleaseAssets` accesses `request.patterns`, passes them to `resolveUploadFiles`, and the result is assigned to a variable named `files`. The input error messages mix these concepts (e.g., `Input 'files' must include at least one path or glob pattern`).
+
+## Evidence
+
+- path: "src/action/request.ts"
+  loc: "38: patterns: string[]"
+  note: "Internal field uses 'patterns' for the parsed 'files' input."
+- path: "action.yml"
+  loc: "inputs.files"
+  note: "External action API uses 'files' to represent both literal file paths and glob patterns."
+- path: "src/domain/release-asset-plan.ts"
+  loc: "12: export function parseFilePatterns(value: string | undefined): string[]"
+  note: "The adapter/parser function acknowledges both 'files' and 'patterns' in its name."
+
+## Change Scope
+
+- `src/domain/release-asset-plan.ts`
+- `src/action/request.ts`
+- `src/app/upload-release-assets.ts`

--- a/.jules/exchange/events/inconsistent_tag_terminology_taxonomy.md
+++ b/.jules/exchange/events/inconsistent_tag_terminology_taxonomy.md
@@ -1,0 +1,35 @@
+---
+label: "refacts"
+created_at: "2026-03-25"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The term `tag` and `tag_name` are used interchangeably to represent the git tag associated with a GitHub Release. The CLI action input is `tag` and the output is `tag_name`. Internally, the request object uses `tag` but the domain record uses `tagName`.
+
+## Goal
+
+Unify terminology: establish whether the domain concept should universally use `tagName` (which aligns with GitHub's API and the action's output) or remain split based on input/output boundaries.
+
+## Context
+
+The `PrepareActionRequest` uses `tag: string`. The `GitHubReleaseApi` uses `tag_name` in its requests and `mapRelease` maps it to `tagName` in `ReleaseRecord`. The action input is `tag` (e.g., `readRequiredInput('tag')`), while the output is `tag_name` (`core.setOutput('tag_name', result.tagName)`). This inconsistency creates a mental overhead when tracking the value across boundaries.
+
+## Evidence
+
+- path: "src/domain/release-target.ts"
+  loc: "PrepareReleaseTarget.tag: string"
+  note: "Domain object representing a target uses `tag`, while `ReleaseRecord` uses `tagName`."
+- path: "src/domain/release-record.ts"
+  loc: "11: tagName: string"
+  note: "Domain representation uses `tagName`."
+- path: "action.yml"
+  loc: "inputs.tag vs outputs.tag_name"
+  note: "CLI/Action boundary exposes two different names for the same underlying concept."
+
+## Change Scope
+
+- `src/domain/release-target.ts`
+- `src/action/request.ts`


### PR DESCRIPTION
This PR emits three event files detailing taxonomy findings related to inconsistent naming across the codebase boundaries, fulfilling the "Taxonomy Observer" role constraints.

---
*PR created automatically by Jules for task [648721713910365485](https://jules.google.com/task/648721713910365485) started by @akitorahayashi*