### PR TITLE
docs: add data architecture observer events

### DIFF
--- a/.jules/exchange/events/excessive_data_coupling_upload_data_arch.md
+++ b/.jules/exchange/events/excessive_data_coupling_upload_data_arch.md
@@ -1,0 +1,35 @@
+---
+label: "refacts"
+created_at: "2024-03-25"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+The upload process requires passing an entire `ReleaseRecord` object when only the `releaseId` is actually needed, representing excessive data coupling.
+
+## Goal
+
+Reduce data coupling by requiring only the minimum necessary identifier (the `releaseId`) rather than the entire aggregate record.
+
+## Context
+
+In `uploadReleaseAsset`, the `GitHubReleaseApi` requires the entire `ReleaseRecord` object to be passed as an argument. However, inspecting the implementation of `uploadReleaseAsset` reveals that the only field actually accessed on the `ReleaseRecord` is its `id` (`release.id`). This unnecessarily broadens the function signature, making it harder to test and creating a false dependency on having a full release object when only an ID is needed.
+
+## Evidence
+
+- path: "src/adapters/github/release-api.ts"
+  loc: "35"
+  note: "`GitHubReleaseApi.uploadReleaseAsset` signature requires a full `ReleaseRecord` object."
+- path: "src/adapters/github/release-api.ts"
+  loc: "203"
+  note: "The implementation only accesses `release.id` and ignores all other fields on the object."
+- path: "src/app/upload-release-assets.ts"
+  loc: "57"
+  note: "The caller must pass the full `release` object to `uploadReleaseAsset`."
+
+## Change Scope
+
+- `src/adapters/github/release-api.ts`
+- `src/app/upload-release-assets.ts`

--- a/.jules/exchange/events/github_api_fs_coupling_data_arch.md
+++ b/.jules/exchange/events/github_api_fs_coupling_data_arch.md
@@ -1,0 +1,33 @@
+---
+label: "refacts"
+created_at: "2024-03-25"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+The GitHub API adapter has a direct dependency on local file system operations inside its metadata resolution process.
+
+## Goal
+
+Decouple the API adapter from local file operations to maintain strict boundary sovereignty and prevent the infrastructure layer from containing hidden side-effects.
+
+## Context
+
+The `GitHubReleaseApi` is responsible for interacting with the remote GitHub REST API. However, its implementation of `resolveMetadata` dynamically imports and invokes `readReleaseBodyFromPath` from `../fs/release-files.js`. This creates an invisible coupling where an API abstraction suddenly triggers local file I/O operations, violating the principle of keeping domain models and adapters independent of unrelated transport/infrastructure concerns. The resolution of metadata (including file reading) should occur before invoking the API layer.
+
+## Evidence
+
+- path: "src/adapters/github/release-api.ts"
+  loc: "220-224"
+  note: "`resolveMetadata` dynamically imports `../fs/release-files.js` to read files, tightly coupling the GitHub API adapter to the file system."
+- path: "src/adapters/github/release-api.ts"
+  loc: "206-210"
+  note: "The `GitHubReleaseApi` interface defines `resolveMetadata`, requiring any API implementation to know how to resolve local file metadata."
+
+## Change Scope
+
+- `src/adapters/github/release-api.ts`
+- `src/app/prepare-release.ts`
+- `src/app/publish-release.ts`

--- a/.jules/exchange/events/unused_domain_models_data_arch.md
+++ b/.jules/exchange/events/unused_domain_models_data_arch.md
@@ -1,0 +1,36 @@
+---
+label: "refacts"
+created_at: "2024-03-25"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Duplicate definitions exist for core domain models representing request states, with the actual definitions remaining completely unused while transport-level DTOs duplicate their fields.
+
+## Goal
+
+Ensure a single source of truth for domain concepts by utilizing the defined domain models instead of duplicating their fields directly into transport action requests.
+
+## Context
+
+The repository defines `UploadAssetPlan` and `ReleaseTarget` (with `PrepareReleaseTarget`) as core domain representations for release targets and upload plans. However, these are never imported or used. Instead, `ActionRequest` definitions in `src/action/request.ts` duplicate all these fields (e.g. `UploadActionRequest` duplicates `releaseId`, `patterns`, `overwrite`, `failOnUnmatchedFiles`, `workingDirectory`), causing the persistence/transport boundary to bypass the domain boundary entirely.
+
+## Evidence
+
+- path: "src/domain/release-asset-plan.ts"
+  loc: "1-7"
+  note: "`UploadAssetPlan` is defined but never used anywhere in the codebase."
+- path: "src/domain/release-target.ts"
+  loc: "1-7"
+  note: "`ReleaseTarget` and `PrepareReleaseTarget` are defined but completely unused."
+- path: "src/action/request.ts"
+  loc: "15-38"
+  note: "`ActionRequest` types duplicate all fields from the unused domain models instead of composing them."
+
+## Change Scope
+
+- `src/domain/release-asset-plan.ts`
+- `src/domain/release-target.ts`
+- `src/action/request.ts`


### PR DESCRIPTION
This PR introduces 3 high-signal observer events analyzing the `gh-release` application's data architecture, focusing on the boundaries between modules.

1. `unused_domain_models_data_arch.md` - `UploadAssetPlan` and `ReleaseTarget` exist in `src/domain` but are bypassed as their properties are duplicated into `ActionRequest` interface layers.
2. `excessive_data_coupling_upload_data_arch.md` - Identifies that `uploadReleaseAsset` expects a full `ReleaseRecord` while only consuming `release.id`.
3. `github_api_fs_coupling_data_arch.md` - Identifies that the remote GitHub API's `resolveMetadata` invokes local filesystem operations, mixing infrastructure/API layers together.

No production or source code was changed.

---
*PR created automatically by Jules for task [17754086650002258693](https://jules.google.com/task/17754086650002258693) started by @akitorahayashi*