### PR TITLE
Add typescripter event for unsafe type assertion

### DIFF
--- a/.jules/exchange/events/unsafe_type_assertion_typescripter.md
+++ b/.jules/exchange/events/unsafe_type_assertion_typescripter.md
@@ -1,0 +1,28 @@
+---
+label: "refacts"
+created_at: "2024-03-25"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+In `src/adapters/github/release-api.ts`, `data: assetData as unknown as string` is used to bypass the type checker when uploading release assets using Octokit.
+
+## Goal
+
+Refactor the boundary type integration to avoid `as unknown as string` and instead use the correct type definition or safe validation before passing to the API.
+
+## Context
+
+The `uploadReleaseAsset` method reads a file as a `Buffer` (`assetData`). The Octokit `.rest.repos.uploadReleaseAsset` method takes a parameter `data`. Bypassing types using `as unknown as string` hides type mismatches and can cause runtime issues if the underlying API changes or behaves unexpectedly with binary data masquerading as a string. Bypassing types using `as` is an anti-pattern.
+
+## Evidence
+
+- path: "src/adapters/github/release-api.ts"
+  loc: "line 218"
+  note: "data: assetData as unknown as string"
+
+## Change Scope
+
+- `src/adapters/github/release-api.ts`


### PR DESCRIPTION
- Created an event file for an unsafe type assertion (`as unknown as string`) found in `src/adapters/github/release-api.ts`.
- The event points out that bypassing the type checker using `as` hides type mismatches at the boundary and violates the Typescripter role guidelines.

---
*PR created automatically by Jules for task [14734951405403222394](https://jules.google.com/task/14734951405403222394) started by @akitorahayashi*