### PR TITLE
docs: emit consistency observer events

### DIFF
--- a/.jules/exchange/events/metadata_boundary_parsing_consistency.md
+++ b/.jules/exchange/events/metadata_boundary_parsing_consistency.md
@@ -1,0 +1,33 @@
+---
+label: "docs"
+created_at: "2025-05-18"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Problem
+
+The documentation in `docs/configuration.md` contradicts the runtime implementation in `src/action/request.ts` regarding how omitted metadata inputs (`generate_notes` and `prerelease`) are handled. The documentation states these inputs remain "unset at the action boundary" and only resolve to false behavior later. However, `src/action/request.ts` explicitly falls back to `false` when parsing these values, meaning they are resolved to `false` directly at the action boundary.
+
+## Goal
+
+Resolve the contradiction between documented behavior and runtime logic. Either update `docs/configuration.md` to state that omitted `generate_notes` and `prerelease` default to `false` at the action boundary, or modify `src/action/request.ts` to leave them as `undefined` and push the `false` resolution to the `prepare` or `publish` lifecycle use cases.
+
+## Context
+
+A core responsibility of this codebase is to strictly handle boundary inputs, separate from pure domain logic. The documentation emphasizes this distinction ("remain unset at the action boundary"). The implementation's choice to aggressively provide a `false` default within `resolveMetadataInputs` breaks this documented invariant and causes drift.
+
+## Evidence
+
+- path: "docs/configuration.md"
+  loc: "line 48"
+  note: "States: 'When `generate_notes` and `prerelease` are omitted, they remain unset at the action boundary and resolve to false behavior only in prepare or publish mode.'"
+
+- path: "src/action/request.ts"
+  loc: "lines 116-125"
+  note: "Both `generateNotes` and `prerelease` are parsed using `parseOptionalBooleanInput(..., ..., false)`, which assigns `false` immediately instead of leaving them unset (undefined)."
+
+## Change Scope
+
+- `docs/configuration.md`
+- `src/action/request.ts`

--- a/.jules/exchange/events/missing_verification_commands_consistency.md
+++ b/.jules/exchange/events/missing_verification_commands_consistency.md
@@ -1,0 +1,33 @@
+---
+label: "docs"
+created_at: "2025-05-18"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Problem
+
+The central documentation index (`docs/README.md`) claims that `docs/usage.md` contains "verification commands". However, the target document (`docs/usage.md`) contains no such commands. It only contains YAML workflow snippets and migration notes.
+
+## Goal
+
+Align the documentation. Either `docs/usage.md` should be updated to include the promised verification commands, or the reference in `docs/README.md` should be removed so it accurately reflects the current state of `docs/usage.md`.
+
+## Context
+
+Documentation acts as a contract. When an index or summary document lists features, sections, or commands that do not exist in the linked target file, it causes confusion and reduces trust in the documentation. This is a clear case of "outdated docs referencing removed/renamed workflows" or drift between documentation sources where one claims content that the other does not provide.
+
+## Evidence
+
+- path: "docs/README.md"
+  loc: "line 7"
+  note: "States `- [Usage](usage.md): prepare, upload, publish workflow patterns and verification commands`."
+
+- path: "docs/usage.md"
+  loc: "entire file"
+  note: "Does not contain any verification commands, only YAML workflow examples and migration notes."
+
+## Change Scope
+
+- `docs/README.md`
+- `docs/usage.md`


### PR DESCRIPTION
Emit consistency observer events to detect drift between documentation and implementation.

---
*PR created automatically by Jules for task [3890754122731699888](https://jules.google.com/task/3890754122731699888) started by @akitorahayashi*