### PR TITLE
test: add missing tests for uploadReleaseAssets fallback and overwrite false logic

### DIFF
--- a/tests/app/upload-release-assets.test.ts
+++ b/tests/app/upload-release-assets.test.ts
@@ -26,16 +26,18 @@ describe('uploadReleaseAssets', () => {
   it('returns default metadata gracefully when failOnUnmatchedFiles is false and files input matches nothing', async () => {
     vi.mocked(resolveUploadFiles).mockResolvedValue([])
 
+    const mockRelease = {
+      id: 3,
+      tagName: 'v1',
+      uploadUrl: 'u',
+      htmlUrl: 'h',
+      draft: true,
+      prerelease: false,
+      assets: [],
+    }
+
     const api = buildApi({
-      getReleaseById: vi.fn().mockResolvedValue({
-        id: 3,
-        tagName: 'v1',
-        uploadUrl: 'u',
-        htmlUrl: 'h',
-        draft: true,
-        prerelease: false,
-        assets: [],
-      }),
+      getReleaseById: vi.fn().mockResolvedValue(mockRelease),
     })
 
     const result = await uploadReleaseAssets(
@@ -43,7 +45,7 @@ describe('uploadReleaseAssets', () => {
         mode: 'upload',
         repository: 'o/r',
         token: 't',
-        releaseId: 3,
+        releaseId: mockRelease.id,
         patterns: ['dist/*.tgz'],
         overwrite: false,
         failOnUnmatchedFiles: false,
@@ -53,12 +55,12 @@ describe('uploadReleaseAssets', () => {
     )
 
     expect(result).toEqual({
-      releaseId: 3,
-      uploadUrl: 'u',
-      htmlUrl: 'h',
-      tagName: 'v1',
+      releaseId: mockRelease.id,
+      uploadUrl: mockRelease.uploadUrl,
+      htmlUrl: mockRelease.htmlUrl,
+      tagName: mockRelease.tagName,
       created: false,
-      draft: true,
+      draft: mockRelease.draft,
       uploadedAssets: [],
     })
   })
@@ -88,27 +90,21 @@ describe('uploadReleaseAssets', () => {
       { path: '/tmp/a.tgz', name: 'a.tgz' },
     ])
 
+    const mockRelease = {
+      id: 3,
+      tagName: 'v1',
+      uploadUrl: 'u',
+      htmlUrl: 'h',
+      draft: true,
+      prerelease: false,
+      assets: [],
+    }
+
     const api = buildApi({
       getReleaseById: vi
         .fn()
-        .mockResolvedValueOnce({
-          id: 3,
-          tagName: 'v1',
-          uploadUrl: 'u',
-          htmlUrl: 'h',
-          draft: true,
-          prerelease: false,
-          assets: [],
-        })
-        .mockResolvedValueOnce({
-          id: 3,
-          tagName: 'v1',
-          uploadUrl: 'u',
-          htmlUrl: 'h',
-          draft: true,
-          prerelease: false,
-          assets: [],
-        }),
+        .mockResolvedValueOnce(mockRelease)
+        .mockResolvedValueOnce(mockRelease),
       listReleaseAssets: vi.fn().mockResolvedValue([
         {
           id: 10,
@@ -133,7 +129,7 @@ describe('uploadReleaseAssets', () => {
         mode: 'upload',
         repository: 'o/r',
         token: 't',
-        releaseId: 3,
+        releaseId: mockRelease.id,
         patterns: ['dist/*.tgz'],
         overwrite: true,
         failOnUnmatchedFiles: true,
@@ -151,25 +147,27 @@ describe('uploadReleaseAssets', () => {
       { path: '/tmp/a.tgz', name: 'a.tgz' },
     ])
 
+    const mockRelease = {
+      id: 3,
+      tagName: 'v1',
+      uploadUrl: 'u',
+      htmlUrl: 'h',
+      draft: true,
+      prerelease: false,
+      assets: [],
+    }
+
+    const mockExistingAsset = {
+      id: 10,
+      name: 'a.tgz',
+      size: 1,
+      contentType: 'application/gzip',
+      downloadUrl: 'x',
+    }
+
     const api = buildApi({
-      getReleaseById: vi.fn().mockResolvedValue({
-        id: 3,
-        tagName: 'v1',
-        uploadUrl: 'u',
-        htmlUrl: 'h',
-        draft: true,
-        prerelease: false,
-        assets: [],
-      }),
-      listReleaseAssets: vi.fn().mockResolvedValue([
-        {
-          id: 10,
-          name: 'a.tgz',
-          size: 1,
-          contentType: 'application/gzip',
-          downloadUrl: 'x',
-        },
-      ]),
+      getReleaseById: vi.fn().mockResolvedValue(mockRelease),
+      listReleaseAssets: vi.fn().mockResolvedValue([mockExistingAsset]),
     })
 
     await expect(
@@ -178,7 +176,7 @@ describe('uploadReleaseAssets', () => {
           mode: 'upload',
           repository: 'o/r',
           token: 't',
-          releaseId: 3,
+          releaseId: mockRelease.id,
           patterns: ['dist/*.tgz'],
           overwrite: false,
           failOnUnmatchedFiles: true,
@@ -195,16 +193,18 @@ describe('uploadReleaseAssets', () => {
       { path: '/tmp/macos/a.tgz', name: 'a.tgz' },
     ])
 
+    const mockRelease = {
+      id: 3,
+      tagName: 'v1',
+      uploadUrl: 'u',
+      htmlUrl: 'h',
+      draft: true,
+      prerelease: false,
+      assets: [],
+    }
+
     const api = buildApi({
-      getReleaseById: vi.fn().mockResolvedValue({
-        id: 3,
-        tagName: 'v1',
-        uploadUrl: 'u',
-        htmlUrl: 'h',
-        draft: true,
-        prerelease: false,
-        assets: [],
-      }),
+      getReleaseById: vi.fn().mockResolvedValue(mockRelease),
     })
 
     await expect(
@@ -213,7 +213,7 @@ describe('uploadReleaseAssets', () => {
           mode: 'upload',
           repository: 'o/r',
           token: 't',
-          releaseId: 3,
+          releaseId: mockRelease.id,
           patterns: ['dist/**/*.tgz'],
           overwrite: false,
           failOnUnmatchedFiles: true,

--- a/tests/app/upload-release-assets.test.ts
+++ b/tests/app/upload-release-assets.test.ts
@@ -23,6 +23,46 @@ function buildApi(overrides: Partial<GitHubReleaseApi>): GitHubReleaseApi {
 }
 
 describe('uploadReleaseAssets', () => {
+  it('returns default metadata gracefully when failOnUnmatchedFiles is false and files input matches nothing', async () => {
+    vi.mocked(resolveUploadFiles).mockResolvedValue([])
+
+    const api = buildApi({
+      getReleaseById: vi.fn().mockResolvedValue({
+        id: 3,
+        tagName: 'v1',
+        uploadUrl: 'u',
+        htmlUrl: 'h',
+        draft: true,
+        prerelease: false,
+        assets: [],
+      }),
+    })
+
+    const result = await uploadReleaseAssets(
+      {
+        mode: 'upload',
+        repository: 'o/r',
+        token: 't',
+        releaseId: 3,
+        patterns: ['dist/*.tgz'],
+        overwrite: false,
+        failOnUnmatchedFiles: false,
+        workingDirectory: '.',
+      },
+      api,
+    )
+
+    expect(result).toEqual({
+      releaseId: 3,
+      uploadUrl: 'u',
+      htmlUrl: 'h',
+      tagName: 'v1',
+      created: false,
+      draft: true,
+      uploadedAssets: [],
+    })
+  })
+
   it('fails when files input is empty', async () => {
     const api = buildApi({})
 
@@ -104,6 +144,49 @@ describe('uploadReleaseAssets', () => {
 
     expect(result.uploadedAssets).toHaveLength(1)
     expect(api.deleteReleaseAsset).toHaveBeenCalledWith('o/r', 10)
+  })
+
+  it('fails when an asset already exists and overwrite is false', async () => {
+    vi.mocked(resolveUploadFiles).mockResolvedValue([
+      { path: '/tmp/a.tgz', name: 'a.tgz' },
+    ])
+
+    const api = buildApi({
+      getReleaseById: vi.fn().mockResolvedValue({
+        id: 3,
+        tagName: 'v1',
+        uploadUrl: 'u',
+        htmlUrl: 'h',
+        draft: true,
+        prerelease: false,
+        assets: [],
+      }),
+      listReleaseAssets: vi.fn().mockResolvedValue([
+        {
+          id: 10,
+          name: 'a.tgz',
+          size: 1,
+          contentType: 'application/gzip',
+          downloadUrl: 'x',
+        },
+      ]),
+    })
+
+    await expect(
+      uploadReleaseAssets(
+        {
+          mode: 'upload',
+          repository: 'o/r',
+          token: 't',
+          releaseId: 3,
+          patterns: ['dist/*.tgz'],
+          overwrite: false,
+          failOnUnmatchedFiles: true,
+          workingDirectory: '.',
+        },
+        api,
+      ),
+    ).rejects.toThrow("Asset 'a.tgz' already exists and overwrite is disabled.")
   })
 
   it('fails when multiple matched files resolve to the same asset name', async () => {


### PR DESCRIPTION
Implements missing test coverage specified in `.jules/exchange/requirements/improve_upload_release_assets_test_coverage.md`. Specifically validates:

- `overwrite: false` throws exactly `Asset '${file.name}' already exists and overwrite is disabled.`
- `failOnUnmatchedFiles: false` with 0 matching files returns default fallback metadata correctly (no error, `uploadedAssets: []`).

---
*PR created automatically by Jules for task [373117303822684511](https://jules.google.com/task/373117303822684511) started by @akitorahayashi*