### PR TITLE
test: add prepare-release fallback logic coverage

### DIFF
--- a/tests/app/prepare-release.test.ts
+++ b/tests/app/prepare-release.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it, vi } from 'vitest'
 import { prepareRelease } from '../../src/app/prepare-release'
-import type { GitHubReleaseApi } from '../../src/adapters/github/release-api'
+import {
+  GitHubApiError,
+  type GitHubReleaseApi,
+} from '../../src/adapters/github/release-api'
+
+vi.mock('../../src/adapters/time/sleep', () => ({
+  sleep: vi.fn().mockResolvedValue(undefined),
+}))
 
 function buildApi(overrides: Partial<GitHubReleaseApi>): GitHubReleaseApi {
   return {
@@ -138,6 +145,143 @@ describe('prepareRelease', () => {
         api,
       ),
     ).rejects.toThrow("No release exists for tag 'v1'")
+  })
+
+  it('retries up to the maximum bounded attempts on retryable statuses and succeeds', async () => {
+    const createDraftRelease = vi
+      .fn()
+      .mockRejectedValueOnce(new GitHubApiError('Internal Server Error', 500))
+      .mockRejectedValueOnce(new GitHubApiError('Bad Gateway', 502))
+      .mockResolvedValueOnce({
+        id: 9,
+        tagName: 'v1',
+        uploadUrl: 'u',
+        htmlUrl: 'h',
+        draft: true,
+        prerelease: false,
+        assets: [],
+      })
+
+    const api = buildApi({
+      findReleasesByTag: vi.fn().mockResolvedValue([]),
+      resolveMetadata: vi.fn().mockResolvedValue({ name: 'R' }),
+      createDraftRelease,
+    })
+
+    const result = await prepareRelease(
+      {
+        mode: 'prepare',
+        repository: 'o/r',
+        token: 't',
+        tag: 'v1',
+        create: true,
+        metadata: {
+          name: 'R',
+          body: undefined,
+          bodyPath: undefined,
+          generateNotes: false,
+          generateNotesProvided: true,
+          prerelease: false,
+          prereleaseProvided: true,
+          makeLatest: undefined,
+          makeLatestProvided: false,
+        },
+      },
+      api,
+    )
+
+    expect(createDraftRelease).toHaveBeenCalledTimes(3)
+    expect(result.created).toBe(true)
+    expect(result.releaseId).toBe(9)
+  })
+
+  it('fails accurately when all bounded retries are exhausted', async () => {
+    const createDraftRelease = vi
+      .fn()
+      .mockRejectedValue(new GitHubApiError('Internal Server Error', 500))
+
+    const api = buildApi({
+      findReleasesByTag: vi.fn().mockResolvedValue([]),
+      resolveMetadata: vi.fn().mockResolvedValue({ name: 'R' }),
+      createDraftRelease,
+    })
+
+    await expect(
+      prepareRelease(
+        {
+          mode: 'prepare',
+          repository: 'o/r',
+          token: 't',
+          tag: 'v1',
+          create: true,
+          metadata: {
+            name: 'R',
+            body: undefined,
+            bodyPath: undefined,
+            generateNotes: false,
+            generateNotesProvided: true,
+            prerelease: false,
+            prereleaseProvided: true,
+            makeLatest: undefined,
+            makeLatestProvided: false,
+          },
+        },
+        api,
+      ),
+    ).rejects.toThrow('Internal Server Error')
+
+    expect(createDraftRelease).toHaveBeenCalledTimes(5)
+  })
+
+  it('handles 409 conflicts by returning the converged state', async () => {
+    const createDraftRelease = vi
+      .fn()
+      .mockRejectedValue(new GitHubApiError('Conflict', 409))
+
+    const api = buildApi({
+      findReleasesByTag: vi
+        .fn()
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          {
+            id: 10,
+            tagName: 'v1',
+            uploadUrl: 'u',
+            htmlUrl: 'h',
+            draft: true,
+            prerelease: false,
+            assets: [],
+          },
+        ]),
+      resolveMetadata: vi.fn().mockResolvedValue({ name: 'R' }),
+      createDraftRelease,
+    })
+
+    const result = await prepareRelease(
+      {
+        mode: 'prepare',
+        repository: 'o/r',
+        token: 't',
+        tag: 'v1',
+        create: true,
+        metadata: {
+          name: 'R',
+          body: undefined,
+          bodyPath: undefined,
+          generateNotes: false,
+          generateNotesProvided: true,
+          prerelease: false,
+          prereleaseProvided: true,
+          makeLatest: undefined,
+          makeLatestProvided: false,
+        },
+      },
+      api,
+    )
+
+    expect(createDraftRelease).toHaveBeenCalledTimes(1)
+    expect(result.created).toBe(false)
+    expect(result.releaseId).toBe(10)
   })
 
   it('fails when multiple releases already exist for the same tag', async () => {

--- a/tests/app/prepare-release.test.ts
+++ b/tests/app/prepare-release.test.ts
@@ -4,6 +4,7 @@ import {
   GitHubApiError,
   type GitHubReleaseApi,
 } from '../../src/adapters/github/release-api'
+import type { PrepareActionRequest } from '../../src/action/request'
 
 vi.mock('../../src/adapters/time/sleep', () => ({
   sleep: vi.fn().mockResolvedValue(undefined),
@@ -24,6 +25,25 @@ function buildApi(overrides: Partial<GitHubReleaseApi>): GitHubReleaseApi {
 }
 
 describe('prepareRelease', () => {
+  const baseRequest: PrepareActionRequest = {
+    mode: 'prepare',
+    repository: 'o/r',
+    token: 't',
+    tag: 'v1',
+    create: true,
+    metadata: {
+      name: 'R',
+      body: undefined,
+      bodyPath: undefined,
+      generateNotes: false,
+      generateNotesProvided: true,
+      prerelease: false,
+      prereleaseProvided: true,
+      makeLatest: undefined,
+      makeLatestProvided: false,
+    },
+  }
+
   it('updates existing release and reports created false', async () => {
     const api = buildApi({
       findReleasesByTag: vi.fn().mockResolvedValue([
@@ -49,27 +69,7 @@ describe('prepareRelease', () => {
       }),
     })
 
-    const result = await prepareRelease(
-      {
-        mode: 'prepare',
-        repository: 'o/r',
-        token: 't',
-        tag: 'v1',
-        create: true,
-        metadata: {
-          name: 'R',
-          body: undefined,
-          bodyPath: undefined,
-          generateNotes: false,
-          generateNotesProvided: true,
-          prerelease: false,
-          prereleaseProvided: true,
-          makeLatest: undefined,
-          makeLatestProvided: false,
-        },
-      },
-      api,
-    )
+    const result = await prepareRelease(baseRequest, api)
 
     expect(result.created).toBe(false)
     expect(result.releaseId).toBe(7)
@@ -91,29 +91,9 @@ describe('prepareRelease', () => {
       resolveMetadata: vi.fn().mockResolvedValue({}),
     })
 
-    await expect(
-      prepareRelease(
-        {
-          mode: 'prepare',
-          repository: 'o/r',
-          token: 't',
-          tag: 'v1',
-          create: true,
-          metadata: {
-            name: undefined,
-            body: undefined,
-            bodyPath: undefined,
-            generateNotes: false,
-            generateNotesProvided: false,
-            prerelease: false,
-            prereleaseProvided: false,
-            makeLatest: undefined,
-            makeLatestProvided: false,
-          },
-        },
-        api,
-      ),
-    ).rejects.toThrow("Release for tag 'v1' already exists and is published.")
+    await expect(prepareRelease(baseRequest, api)).rejects.toThrow(
+      "Release for tag 'v1' already exists and is published.",
+    )
   })
 
   it('fails when release is missing and create is false', async () => {
@@ -123,27 +103,7 @@ describe('prepareRelease', () => {
     })
 
     await expect(
-      prepareRelease(
-        {
-          mode: 'prepare',
-          repository: 'o/r',
-          token: 't',
-          tag: 'v1',
-          create: false,
-          metadata: {
-            name: undefined,
-            body: undefined,
-            bodyPath: undefined,
-            generateNotes: false,
-            generateNotesProvided: false,
-            prerelease: false,
-            prereleaseProvided: false,
-            makeLatest: undefined,
-            makeLatestProvided: false,
-          },
-        },
-        api,
-      ),
+      prepareRelease({ ...baseRequest, create: false }, api),
     ).rejects.toThrow("No release exists for tag 'v1'")
   })
 
@@ -168,27 +128,7 @@ describe('prepareRelease', () => {
       createDraftRelease,
     })
 
-    const result = await prepareRelease(
-      {
-        mode: 'prepare',
-        repository: 'o/r',
-        token: 't',
-        tag: 'v1',
-        create: true,
-        metadata: {
-          name: 'R',
-          body: undefined,
-          bodyPath: undefined,
-          generateNotes: false,
-          generateNotesProvided: true,
-          prerelease: false,
-          prereleaseProvided: true,
-          makeLatest: undefined,
-          makeLatestProvided: false,
-        },
-      },
-      api,
-    )
+    const result = await prepareRelease(baseRequest, api)
 
     expect(createDraftRelease).toHaveBeenCalledTimes(3)
     expect(result.created).toBe(true)
@@ -206,29 +146,9 @@ describe('prepareRelease', () => {
       createDraftRelease,
     })
 
-    await expect(
-      prepareRelease(
-        {
-          mode: 'prepare',
-          repository: 'o/r',
-          token: 't',
-          tag: 'v1',
-          create: true,
-          metadata: {
-            name: 'R',
-            body: undefined,
-            bodyPath: undefined,
-            generateNotes: false,
-            generateNotesProvided: true,
-            prerelease: false,
-            prereleaseProvided: true,
-            makeLatest: undefined,
-            makeLatestProvided: false,
-          },
-        },
-        api,
-      ),
-    ).rejects.toThrow('Internal Server Error')
+    await expect(prepareRelease(baseRequest, api)).rejects.toThrow(
+      'Internal Server Error',
+    )
 
     expect(createDraftRelease).toHaveBeenCalledTimes(5)
   })
@@ -257,27 +177,7 @@ describe('prepareRelease', () => {
       createDraftRelease,
     })
 
-    const result = await prepareRelease(
-      {
-        mode: 'prepare',
-        repository: 'o/r',
-        token: 't',
-        tag: 'v1',
-        create: true,
-        metadata: {
-          name: 'R',
-          body: undefined,
-          bodyPath: undefined,
-          generateNotes: false,
-          generateNotesProvided: true,
-          prerelease: false,
-          prereleaseProvided: true,
-          makeLatest: undefined,
-          makeLatestProvided: false,
-        },
-      },
-      api,
-    )
+    const result = await prepareRelease(baseRequest, api)
 
     expect(createDraftRelease).toHaveBeenCalledTimes(1)
     expect(result.created).toBe(false)
@@ -309,28 +209,8 @@ describe('prepareRelease', () => {
       resolveMetadata: vi.fn().mockResolvedValue({}),
     })
 
-    await expect(
-      prepareRelease(
-        {
-          mode: 'prepare',
-          repository: 'o/r',
-          token: 't',
-          tag: 'v1',
-          create: true,
-          metadata: {
-            name: undefined,
-            body: undefined,
-            bodyPath: undefined,
-            generateNotes: false,
-            generateNotesProvided: false,
-            prerelease: false,
-            prereleaseProvided: false,
-            makeLatest: undefined,
-            makeLatestProvided: false,
-          },
-        },
-        api,
-      ),
-    ).rejects.toThrow("Multiple releases already exist for tag 'v1'")
+    await expect(prepareRelease(baseRequest, api)).rejects.toThrow(
+      "Multiple releases already exist for tag 'v1'",
+    )
   })
 })


### PR DESCRIPTION
This PR adds test coverage for the fallback logic in `prepareRelease`, ensuring that bounded retries on retryable errors and converged state resolution on conflicts are working correctly.

---
*PR created automatically by Jules for task [3993996166016046139](https://jules.google.com/task/3993996166016046139) started by @akitorahayashi*