### PR TITLE
refactor: unify domain model terminology and use composition

### DIFF
--- a/src/action/request.ts
+++ b/src/action/request.ts
@@ -4,7 +4,10 @@ import {
   type ReleaseMetadataInput,
   validateBodyInputs,
 } from '../domain/release-metadata'
-import { parseFilePatterns, type UploadAssetPlan } from '../domain/release-asset-plan'
+import {
+  parseFilePatterns,
+  type UploadAssetPlan,
+} from '../domain/release-asset-plan'
 import { parseReleaseMode, type ReleaseMode } from '../domain/release-mode'
 import { assertMetadataOwnership } from '../domain/release-write-policy'
 import {
@@ -27,17 +30,24 @@ interface BaseRequest {
   token: string
 }
 
-export interface PrepareActionRequest extends Omit<BaseRequest, 'repository'>, PrepareReleaseTarget {
+export interface PrepareActionRequest
+  extends Omit<BaseRequest, 'repository'>,
+    PrepareReleaseTarget {
   mode: 'prepare'
   create: boolean
   metadata: ReleaseMetadataInput
 }
 
-export interface UploadActionRequest extends Omit<BaseRequest, 'repository'>, ReleaseTarget, UploadAssetPlan {
+export interface UploadActionRequest
+  extends Omit<BaseRequest, 'repository'>,
+    ReleaseTarget,
+    UploadAssetPlan {
   mode: 'upload'
 }
 
-export interface PublishActionRequest extends Omit<BaseRequest, 'repository'>, ReleaseTarget {
+export interface PublishActionRequest
+  extends Omit<BaseRequest, 'repository'>,
+    ReleaseTarget {
   mode: 'publish'
   releaseId: number
   publish: boolean

--- a/src/action/request.ts
+++ b/src/action/request.ts
@@ -14,8 +14,8 @@ import {
   normalizeRepository,
   normalizeTag,
   parseReleaseId,
+  type ExistingReleaseTarget,
   type PrepareReleaseTarget,
-  type ReleaseTarget,
 } from '../domain/release-target'
 import {
   parseOptionalBooleanInput,
@@ -40,16 +40,15 @@ export interface PrepareActionRequest
 
 export interface UploadActionRequest
   extends Omit<BaseRequest, 'repository'>,
-    ReleaseTarget,
+    ExistingReleaseTarget,
     UploadAssetPlan {
   mode: 'upload'
 }
 
 export interface PublishActionRequest
   extends Omit<BaseRequest, 'repository'>,
-    ReleaseTarget {
+    ExistingReleaseTarget {
   mode: 'publish'
-  releaseId: number
   publish: boolean
   metadata: ReleaseMetadataInput
 }

--- a/src/action/request.ts
+++ b/src/action/request.ts
@@ -4,13 +4,15 @@ import {
   type ReleaseMetadataInput,
   validateBodyInputs,
 } from '../domain/release-metadata'
-import { parseFilePatterns } from '../domain/release-asset-plan'
+import { parseFilePatterns, type UploadAssetPlan } from '../domain/release-asset-plan'
 import { parseReleaseMode, type ReleaseMode } from '../domain/release-mode'
 import { assertMetadataOwnership } from '../domain/release-write-policy'
 import {
   normalizeRepository,
   normalizeTag,
   parseReleaseId,
+  type PrepareReleaseTarget,
+  type ReleaseTarget,
 } from '../domain/release-target'
 import {
   parseOptionalBooleanInput,
@@ -25,23 +27,17 @@ interface BaseRequest {
   token: string
 }
 
-export interface PrepareActionRequest extends BaseRequest {
+export interface PrepareActionRequest extends Omit<BaseRequest, 'repository'>, PrepareReleaseTarget {
   mode: 'prepare'
-  tag: string
   create: boolean
   metadata: ReleaseMetadataInput
 }
 
-export interface UploadActionRequest extends BaseRequest {
+export interface UploadActionRequest extends Omit<BaseRequest, 'repository'>, ReleaseTarget, UploadAssetPlan {
   mode: 'upload'
-  releaseId: number
-  patterns: string[]
-  overwrite: boolean
-  failOnUnmatchedFiles: boolean
-  workingDirectory: string
 }
 
-export interface PublishActionRequest extends BaseRequest {
+export interface PublishActionRequest extends Omit<BaseRequest, 'repository'>, ReleaseTarget {
   mode: 'publish'
   releaseId: number
   publish: boolean
@@ -70,7 +66,7 @@ export function resolveActionRequest(): ActionRequest {
         mode,
         repository,
         token,
-        tag: normalizeTag(readRequiredInput('tag')),
+        tagName: normalizeTag(readRequiredInput('tag')),
         create: readBooleanInput('create', false),
         metadata,
       }

--- a/src/adapters/github/release-api.ts
+++ b/src/adapters/github/release-api.ts
@@ -212,7 +212,7 @@ export function createGitHubReleaseApi(token: string): GitHubReleaseApi {
       const uploadResponse = await octokit.rest.repos.uploadReleaseAsset({
         owner,
         repo,
-        release_id: release.id,
+        release_id: release.releaseId,
         name: fileName,
         // Octokit runtime accepts Buffer, but current type narrows data to string.
         data: assetData as unknown as string,

--- a/src/adapters/github/release-mapper.ts
+++ b/src/adapters/github/release-mapper.ts
@@ -35,7 +35,7 @@ export function mapReleaseAsset(
 
 export function mapRelease(record: GitHubReleaseLike): ReleaseRecord {
   return {
-    id: record.id,
+    releaseId: record.id,
     tagName: record.tag_name,
     uploadUrl: record.upload_url,
     htmlUrl: record.html_url,

--- a/src/app/prepare-release.ts
+++ b/src/app/prepare-release.ts
@@ -21,13 +21,13 @@ export async function prepareRelease(
   const metadata = await api.resolveMetadata(request.metadata)
 
   const existing = selectPrepareRelease(
-    request.tag,
-    await api.findReleasesByTag(request.repository, request.tag),
+    request.tagName,
+    await api.findReleasesByTag(request.repository, request.tagName),
   )
   if (existing) {
     const updated = await api.updateRelease(
       request.repository,
-      existing.id,
+      existing.releaseId,
       metadata,
       existing.draft,
     )
@@ -36,7 +36,7 @@ export async function prepareRelease(
 
   if (!request.create) {
     throw new Error(
-      `No release exists for tag '${request.tag}'. Set 'create' to true in prepare mode to create a draft release.`,
+      `No release exists for tag '${request.tagName}'. Set 'create' to true in prepare mode to create a draft release.`,
     )
   }
 
@@ -48,7 +48,7 @@ export async function prepareRelease(
     try {
       const created = await api.createDraftRelease(
         request.repository,
-        request.tag,
+        request.tagName,
         metadata,
       )
       return toActionResult(created, true)
@@ -59,8 +59,8 @@ export async function prepareRelease(
 
       if (isConflictStatus(error.status)) {
         const converged = selectPrepareRelease(
-          request.tag,
-          await api.findReleasesByTag(request.repository, request.tag),
+          request.tagName,
+          await api.findReleasesByTag(request.repository, request.tagName),
         )
         if (converged) {
           return toActionResult(converged, false)
@@ -113,7 +113,7 @@ function toActionResult(
   created: boolean,
 ): ActionResult {
   return {
-    releaseId: release.id,
+    releaseId: release.releaseId,
     uploadUrl: release.uploadUrl,
     htmlUrl: release.htmlUrl,
     tagName: release.tagName,

--- a/src/app/publish-release.ts
+++ b/src/app/publish-release.ts
@@ -20,13 +20,13 @@ export async function publishRelease(
   const metadata = await api.resolveMetadata(request.metadata)
   const updated = await api.updateRelease(
     request.repository,
-    release.id,
+    release.releaseId,
     metadata,
     false,
   )
 
   return {
-    releaseId: updated.id,
+    releaseId: updated.releaseId,
     uploadUrl: updated.uploadUrl,
     htmlUrl: updated.htmlUrl,
     tagName: updated.tagName,

--- a/src/app/upload-release-assets.ts
+++ b/src/app/upload-release-assets.ts
@@ -41,7 +41,7 @@ export async function uploadReleaseAssets(
     )
 
     return {
-      releaseId: release.id,
+      releaseId: release.releaseId,
       uploadUrl: release.uploadUrl,
       htmlUrl: release.htmlUrl,
       tagName: release.tagName,
@@ -53,7 +53,7 @@ export async function uploadReleaseAssets(
 
   const existingAssets = await api.listReleaseAssets(
     request.repository,
-    release.id,
+    release.releaseId,
   )
   const existingByName = new Map(
     existingAssets.map((asset) => [asset.name, asset]),
@@ -82,11 +82,11 @@ export async function uploadReleaseAssets(
 
   const refreshedRelease = await api.getReleaseById(
     request.repository,
-    release.id,
+    release.releaseId,
   )
 
   return {
-    releaseId: refreshedRelease.id,
+    releaseId: refreshedRelease.releaseId,
     uploadUrl: refreshedRelease.uploadUrl,
     htmlUrl: refreshedRelease.htmlUrl,
     tagName: refreshedRelease.tagName,

--- a/src/domain/release-asset-plan.ts
+++ b/src/domain/release-asset-plan.ts
@@ -1,5 +1,4 @@
 export interface UploadAssetPlan {
-  releaseId: number
   patterns: string[]
   overwrite: boolean
   failOnUnmatchedFiles: boolean

--- a/src/domain/release-record.ts
+++ b/src/domain/release-record.ts
@@ -7,7 +7,7 @@ export interface ReleaseAssetRecord {
 }
 
 export interface ReleaseRecord {
-  id: number
+  releaseId: number
   tagName: string
   uploadUrl: string
   htmlUrl: string

--- a/src/domain/release-target.ts
+++ b/src/domain/release-target.ts
@@ -2,6 +2,10 @@ export interface ReleaseTarget {
   repository: string
 }
 
+export interface ExistingReleaseTarget extends ReleaseTarget {
+  releaseId: number
+}
+
 export interface PrepareReleaseTarget extends ReleaseTarget {
   tagName: string
 }

--- a/src/domain/release-target.ts
+++ b/src/domain/release-target.ts
@@ -3,7 +3,7 @@ export interface ReleaseTarget {
 }
 
 export interface PrepareReleaseTarget extends ReleaseTarget {
-  tag: string
+  tagName: string
 }
 
 export function normalizeRepository(value: string): string {

--- a/tests/action/request.test.ts
+++ b/tests/action/request.test.ts
@@ -69,7 +69,7 @@ describe('resolveActionRequest', () => {
       mode: 'prepare',
       repository: 'octo/repo',
       token: 'tok',
-      tag: 'v1.2.3',
+      tagName: 'v1.2.3',
       create: true,
       metadata: {
         name: 'Release v1.2.3',
@@ -105,7 +105,7 @@ describe('resolveActionRequest', () => {
       mode: 'prepare',
       repository: 'acme/widget',
       token: 'tok',
-      tag: 'v1',
+      tagName: 'v1',
       create: true,
       metadata: {
         name: undefined,

--- a/tests/adapters/release-api.test.ts
+++ b/tests/adapters/release-api.test.ts
@@ -72,7 +72,7 @@ describe('createGitHubReleaseApi', () => {
     await expect(api.findReleasesByTag('octo/repo', 'v1.2.3')).resolves.toEqual(
       [
         {
-          id: 10,
+          releaseId: 10,
           tagName: 'v1.2.3',
           uploadUrl: 'https://uploads.example.test/release/10{?name,label}',
           htmlUrl: 'https://example.test/release/10',

--- a/tests/adapters/release-mapper.test.ts
+++ b/tests/adapters/release-mapper.test.ts
@@ -25,7 +25,7 @@ describe('release mapper', () => {
     })
 
     expect(record).toEqual({
-      id: 101,
+      releaseId: 101,
       tagName: 'v1.0.0',
       uploadUrl: 'https://uploads.example',
       htmlUrl: 'https://html.example',

--- a/tests/app/prepare-release.test.ts
+++ b/tests/app/prepare-release.test.ts
@@ -21,7 +21,7 @@ describe('prepareRelease', () => {
     const api = buildApi({
       findReleasesByTag: vi.fn().mockResolvedValue([
         {
-          id: 7,
+          releaseId: 7,
           tagName: 'v1',
           uploadUrl: 'u',
           htmlUrl: 'h',
@@ -32,7 +32,7 @@ describe('prepareRelease', () => {
       ]),
       resolveMetadata: vi.fn().mockResolvedValue({ name: 'R' }),
       updateRelease: vi.fn().mockResolvedValue({
-        id: 7,
+        releaseId: 7,
         tagName: 'v1',
         uploadUrl: 'u',
         htmlUrl: 'h',
@@ -47,7 +47,7 @@ describe('prepareRelease', () => {
         mode: 'prepare',
         repository: 'o/r',
         token: 't',
-        tag: 'v1',
+        tagName: 'v1',
         create: true,
         metadata: {
           name: 'R',
@@ -72,7 +72,7 @@ describe('prepareRelease', () => {
     const api = buildApi({
       findReleasesByTag: vi.fn().mockResolvedValue([
         {
-          id: 7,
+          releaseId: 7,
           tagName: 'v1',
           uploadUrl: 'u',
           htmlUrl: 'h',
@@ -90,7 +90,7 @@ describe('prepareRelease', () => {
           mode: 'prepare',
           repository: 'o/r',
           token: 't',
-          tag: 'v1',
+          tagName: 'v1',
           create: true,
           metadata: {
             name: undefined,
@@ -121,7 +121,7 @@ describe('prepareRelease', () => {
           mode: 'prepare',
           repository: 'o/r',
           token: 't',
-          tag: 'v1',
+          tagName: 'v1',
           create: false,
           metadata: {
             name: undefined,
@@ -144,7 +144,7 @@ describe('prepareRelease', () => {
     const api = buildApi({
       findReleasesByTag: vi.fn().mockResolvedValue([
         {
-          id: 7,
+          releaseId: 7,
           tagName: 'v1',
           uploadUrl: 'u1',
           htmlUrl: 'h1',
@@ -153,7 +153,7 @@ describe('prepareRelease', () => {
           assets: [],
         },
         {
-          id: 8,
+          releaseId: 8,
           tagName: 'v1',
           uploadUrl: 'u2',
           htmlUrl: 'h2',
@@ -171,7 +171,7 @@ describe('prepareRelease', () => {
           mode: 'prepare',
           repository: 'o/r',
           token: 't',
-          tag: 'v1',
+          tagName: 'v1',
           create: true,
           metadata: {
             name: undefined,

--- a/tests/app/publish-release.test.ts
+++ b/tests/app/publish-release.test.ts
@@ -48,7 +48,7 @@ describe('publishRelease', () => {
   it('publishes draft release and returns normalized output', async () => {
     const api = buildApi({
       getReleaseById: vi.fn().mockResolvedValue({
-        id: 9,
+        releaseId: 9,
         tagName: 'v1',
         uploadUrl: 'u',
         htmlUrl: 'h',
@@ -58,7 +58,7 @@ describe('publishRelease', () => {
       }),
       resolveMetadata: vi.fn().mockResolvedValue({ name: 'R' }),
       updateRelease: vi.fn().mockResolvedValue({
-        id: 9,
+        releaseId: 9,
         tagName: 'v1',
         uploadUrl: 'u',
         htmlUrl: 'h',

--- a/tests/app/upload-release-assets.test.ts
+++ b/tests/app/upload-release-assets.test.ts
@@ -52,7 +52,7 @@ describe('uploadReleaseAssets', () => {
       getReleaseById: vi
         .fn()
         .mockResolvedValueOnce({
-          id: 3,
+          releaseId: 3,
           tagName: 'v1',
           uploadUrl: 'u',
           htmlUrl: 'h',
@@ -61,7 +61,7 @@ describe('uploadReleaseAssets', () => {
           assets: [],
         })
         .mockResolvedValueOnce({
-          id: 3,
+          releaseId: 3,
           tagName: 'v1',
           uploadUrl: 'u',
           htmlUrl: 'h',
@@ -114,7 +114,7 @@ describe('uploadReleaseAssets', () => {
 
     const api = buildApi({
       getReleaseById: vi.fn().mockResolvedValue({
-        id: 3,
+        releaseId: 3,
         tagName: 'v1',
         uploadUrl: 'u',
         htmlUrl: 'h',


### PR DESCRIPTION
Refactor domain models to unify terminology and use composition. This update changes `id` to `releaseId`, `tag` to `tagName`, and applies `UploadAssetPlan`, `ReleaseTarget`, and `PrepareReleaseTarget` using TS extensions instead of recreating fields in action requests. Also fixes documentation issues and replaces `files` with `patterns`. Tests have been adjusted accordingly and passed.

---
*PR created automatically by Jules for task [18207377099123158313](https://jules.google.com/task/18207377099123158313) started by @akitorahayashi*